### PR TITLE
fix issue after svelte update

### DIFF
--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -28,7 +28,7 @@ export const svelteFramework: ReactiveFramework = {
   effect: (fn) => {
     $.render_effect(fn);
   },
-  withBatch: (fn) => $.flush_sync(fn),
+  withBatch: (fn) => $.flush(fn),
   withBuild: <T>(fn: () => T): T => {
     let res: T | undefined;
     $.effect_root(() => {


### PR DESCRIPTION
Hello,

This is a very small PR to fix an issue after updating Svelte, `flush_sync` is now called `flush` cf https://github.com/sveltejs/svelte/pull/15348